### PR TITLE
Fix - 'NODE_ENV' not recognized error on windows machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
**What ?**
This fix follows an error I encountered while trying to run novelVerse on my windows pc.

`
'NODE_ENV' is not recognized as an internal or external command,
operable program or batch file.
`

**HOW ?**
Edit package.json scripts to use cross-env. Start by installing cross-env:

`npm install cross-env --save-dev`

Then update package.json to include cross-env

**WHY ?**
cross-env handles setting environment variables the right way for both Windows and Unix systems.